### PR TITLE
refactor: remove debug logs, stale directive, and unused field

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -62,8 +62,7 @@ const router = createBrowserRouter(
 
 function App() {
   const app = initializeApp(firebaseConfig)
-  const analytics = getAnalytics(app)
-  console.log(analytics)
+  getAnalytics(app)
   return (
     <>
       <RouterProvider router={router} />

--- a/src/components/DarkModeToggle.tsx
+++ b/src/components/DarkModeToggle.tsx
@@ -6,7 +6,6 @@ const DarkModeToggle: React.FC = () => {
   const { isDark, toggleTheme } = useTheme()
 
   const handleToggle = (): void => {
-    console.log('Toggle clicked, current theme:', isDark ? 'dark' : 'light')
     toggleTheme()
   }
 

--- a/src/components/RunningCatScene.tsx
+++ b/src/components/RunningCatScene.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { useState, useEffect, Suspense, useRef } from 'react'
 import { Canvas } from '@react-three/fiber'
 import { Model } from './Model.tsx'
@@ -105,13 +103,9 @@ export default function RunningCatScene() {
         // Set target rotation to face the correct direction
         const newRotation = movingRight ? Math.PI / 2 : -Math.PI / 2
 
-        console.log(`Cat turning to face ${movingRight ? 'right' : 'left'}`)
         isTurningRef.current = true
         setTargetRotation(newRotation)
         setFacingRight(movingRight)
-      } else if (!directionChanged) {
-        // Same direction, just running
-        console.log('Cat running - using cat_run.glb')
       }
 
       previousPositionRef.current = horizontalPosition
@@ -143,24 +137,14 @@ export default function RunningCatScene() {
           !isTurningRef.current &&
           isAtStableFacingAngle(currentRotationRef.current)
         ) {
-          console.log(
-            'Cat idle - using cat_idle.glb at stable angle:',
-            currentRotationRef.current,
-          )
           setIsMoving(false)
         } else {
-          console.log(
-            'Waiting for turn to complete and reach stable angle before idling',
-          )
           // Re-check after a short delay to allow turn to finish
           const idleCheckInterval = setInterval(() => {
             if (
               !isTurningRef.current &&
               isAtStableFacingAngle(currentRotationRef.current)
             ) {
-              console.log(
-                'Turn complete and stable angle reached - Cat now idle',
-              )
               setIsMoving(false)
               clearInterval(idleCheckInterval)
             }
@@ -170,7 +154,6 @@ export default function RunningCatScene() {
           setTimeout(() => {
             clearInterval(idleCheckInterval)
             if (isMoving) {
-              console.log('Forcing idle state')
               setIsMoving(false)
               isTurningRef.current = false
             }
@@ -199,7 +182,6 @@ export default function RunningCatScene() {
       // Snap to closest proper angle (π/2 for right, -π/2 for left)
       const snappedRotation = adjusted > 0 ? Math.PI / 2 : -Math.PI / 2
 
-      console.log('Locking rotation at stable angle:', snappedRotation)
       setCurrentRotation(snappedRotation)
       currentRotationRef.current = snappedRotation
       return
@@ -213,9 +195,6 @@ export default function RunningCatScene() {
         if (Math.abs(diff) < 0.01) {
           // Turn is complete - allow new turns
           if (isTurningRef.current) {
-            console.log(
-              'Turn rotation completed - ready for new direction changes',
-            )
             isTurningRef.current = false
           }
 

--- a/src/data/profile.json
+++ b/src/data/profile.json
@@ -2,7 +2,6 @@
   "firstName": "Julian",
   "lastName": "Diaz",
   "title": "Frontend & Product Engineer",
-  "greeting": "Hallo! 👋",
   "bio": "Building exceptional web experiences with modern technologies. Transforming ideas into elegant, performant applications.",
   "bioImpersonal": "Five years shipping products across the stack, enterprise fleet SaaS running across 500+ vehicles at ZF Group, real-time learning platforms with live AI transcription, mobile apps in Flutter, and a steady stream of side projects in parallel. Frontend is home base. Product engineer is how I operate: I'll sketch the data model, design the component system, wire up CI, and ship. If there's a blank repo and a real problem, I'm interested.",
   "location": "Berlin, Germany",

--- a/src/pages/NotFoundPage.tsx
+++ b/src/pages/NotFoundPage.tsx
@@ -1,4 +1,3 @@
-// components/NotFoundPage.tsx
 import React from 'react'
 import { Link } from 'react-router-dom'
 import SEO from '../components/SEO'


### PR DESCRIPTION
## Summary
- Removed console.log(analytics) in App.tsx; analytics init kept as side-effect
- Removed debug console.log from DarkModeToggle click handler
- Removed use client Next.js directive from RunningCatScene.tsx (no-op in Vite)
- Removed 6 debug console.log calls tracing cat animation state in RunningCatScene.tsx
- Removed stale file-path comment from NotFoundPage.tsx
- Removed unused greeting field from profile.json

## Test plan
- pnpm build passes with zero TypeScript errors
- Dark mode toggle still works
- Cat animation still runs and idles correctly
- Firebase Analytics still initializes (side-effect call preserved)