### PR TITLE
fix: CSS @import+ lint warning

### DIFF
--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -7,6 +7,7 @@ interface ThemeContextType {
 
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined)
 
+// eslint-disable-next-line react-refresh/only-export-components -- hook colocated with its provider in this small context module
 export const useTheme = (): ThemeContextType => {
   const context = useContext(ThemeContext)
   if (!context) {

--- a/src/index.css
+++ b/src/index.css
@@ -1,14 +1,16 @@
 @import 'tailwindcss';
 
-/* Dark variant — .dark class toggled on <html> by ThemeContext */
-@variant dark (&:where(.dark, .dark *));
-
 /* ─── Typography — npm-sourced fonts ─────────────────────────────────── */
+/* @import rules must precede all other statements (CSS spec), so keep    */
+/* these above @variant and @theme below.                                 */
 @import '@fontsource-variable/archivo/wght.css';
 @import '@fontsource-variable/archivo/wdth.css';
 @import '@fontsource/sometype-mono/400.css';
 @import '@fontsource/sometype-mono/500.css';
 @import '@fontsource/sometype-mono/700.css';
+
+/* Dark variant — .dark class toggled on <html> by ThemeContext */
+@variant dark (&:where(.dark, .dark *));
 
 /* ─── Design tokens — Schematic (light default) ──────────────────────── */
 /* @theme registers these as Tailwind utilities:                          */


### PR DESCRIPTION
## Summary

- **`src/index.css`** — moved `@fontsource` `@import` rules above `@variant dark` per CSS spec, removing the per-build PostCSS warning.
- **`src/context/ThemeContext.tsx`** — scoped `eslint-disable` on `useTheme` so `pnpm lint` (`--max-warnings 0`) passes.

## Verification
- `pnpm build` — succeeds, no `@import` warning
- `pnpm lint` — green