### PR TITLE
fix: pin js-yaml to patched version

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
       "dompurify": "^3.4.13",
       "esbuild": "^0.28.1",
       "form-data": "^4.0.6",
-      "js-yaml": "^4.2.0",
+      "js-yaml": "^4.3.1",
       "protobufjs": "^7.6.5",
       "websocket-driver": ">=0.7.5",
       "brace-expansion@^1.0.0": ">=1.1.17 <2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ overrides:
   dompurify: ^3.4.13
   esbuild: ^0.28.1
   form-data: ^4.0.6
-  js-yaml: ^4.2.0
+  js-yaml: ^4.3.1
   protobufjs: ^7.6.5
   websocket-driver: '>=0.7.5'
   brace-expansion@^1.0.0: '>=1.1.17 <2.0.0'
@@ -2112,8 +2112,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   json-buffer@3.0.1:
@@ -3292,7 +3292,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -5633,7 +5633,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -6372,7 +6372,7 @@ snapshots:
       '@swaggerexpert/cookie': 2.0.2
       deepmerge: 4.3.1
       fast-json-patch: 3.1.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       neotraverse: 0.6.18
       node-abort-controller: 3.1.1
       openapi-path-templating: 2.2.1
@@ -6418,7 +6418,7 @@ snapshots:
       ieee754: 1.2.1
       immutable: 4.3.9
       js-file-download: 0.4.12
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       lodash: 4.18.1
       prop-types: 15.8.1
       randexp: 0.5.3


### PR DESCRIPTION
## Summary
- Tighten the `js-yaml` pnpm override from `^4.2.0` to `^4.3.1`, closing GHSA-5p4m-2wfm-xmqj (quadratic CPU consumption via `!!omap` resolution)
- This was the last open Dependabot alert after #29

## Test plan
- [x] `tsc --noEmit` passes
- [x] `pnpm why js-yaml` confirms `4.3.1` resolves everywhere (runtime, via `swagger-ui-react`, and dev, via eslint tooling)